### PR TITLE
LP-77-Large-badge-UI-Components

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/BagdeButton.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/BagdeButton.kt
@@ -1,0 +1,45 @@
+package com.iteneum.designsystem.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.iteneum.designsystem.theme.Drab
+import com.iteneum.designsystem.theme.MintJulep
+
+@ExperimentalMaterial3Api
+@Composable
+fun BadgeButton(modifier: Modifier = Modifier, onClick : () -> Unit = {}, badgeNumber: Int) {
+
+    Box{
+
+        FilledIconButton(
+            onClick = onClick,
+            colors = IconButtonDefaults.filledIconButtonColors(MintJulep)
+        ) {
+            Icon(Icons.Filled.Notifications, contentDescription = "Notifications button", tint = Drab)
+        }
+
+        if(badgeNumber > 0) {
+            BadgedBox(
+                modifier = modifier.padding(horizontal = 15.dp, vertical = 7.dp).align(Alignment.BottomEnd),
+                badge = {
+                    Badge(
+                        modifier = Modifier
+                            .padding(1.dp)
+                            .align(Alignment.TopEnd)
+                    ) {
+                        Text(text = badgeNumber.toString())
+                    }
+                }
+            ) {
+
+            }
+        }
+    }
+}


### PR DESCRIPTION
LP-77-Large-badge-UI-Components
https://devaptivist.atlassian.net/browse/LP-77
File "BadgeButton.kt" was added. A "BadgeButton" function that instantiates a "bell" icon button (notifications button). It will show a badge number on the bottom right, indicating the amount of notifications available; if does not have any, it will disappear.

IMPORTANT: It requires experimental elements:
@ExperimentalMaterial3Api --> On the function "BadgeButton" (implemented)
@OptIn(ExperimentalMaterial3Api::class) --> On the view that is going to use it

Button Badge with notifications
![BadgeButton1](https://user-images.githubusercontent.com/25538206/229223227-006f5a4e-1b61-4da8-9f95-bbe061476c01.png)
Button Badge without notifications
![BadgeButton2](https://user-images.githubusercontent.com/25538206/229223230-2399c7f6-0bdd-4701-8e22-da16053b4d51.png)
Button Badge Code
![BadgeButtonCode](https://user-images.githubusercontent.com/25538206/229223769-372ae175-728b-448b-891b-fd4560a7886b.png)