### PR TITLE
feature/LP52-elevated-card-with-icon-and-text

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Card.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Card.kt
@@ -1,15 +1,25 @@
 package com.iteneum.designsystem.components
 
+import android.util.Log
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.MaterialTheme
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.iteneum.designsystem.theme.LPTypography
 
 @Composable
 fun LpBasicCard(
@@ -28,3 +38,81 @@ fun LpBasicCard(
         content = content
     )
 }
+
+/**
+ * This function create a card with an icon and description
+ *
+ * @param icon The icon to be displayed
+ * @param description Description to be displayed below the icon
+ * @param onCardClick onClick event when card is clicked
+ * @sample IconTextCardExample This is a usage example
+ *
+ * @author Jose Guadalupe Rivera
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LpIconTextCard(
+    icon: ImageVector,
+    description: String,
+    onCardClick: (String) -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .height(120.dp)
+            .heightIn(120.dp, 250.dp)
+            .padding(8.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.onPrimary),
+        shape = RoundedCornerShape(12.dp),
+        onClick = { onCardClick(description) },
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
+            contentAlignment = Alignment.Center,
+
+            ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = description,
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+                Text(
+                    text = description,
+                    style = LPTypography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onPrimary
+                )
+            }
+        }
+    }
+}
+
+
+// this is an example of LpIconTextCard implementation
+@Preview
+@Composable
+fun IconTextCardExample() {
+    val list = remember {
+        mutableStateListOf("Amenities", "x", "y", "gf")
+    }
+    LazyVerticalGrid(
+        modifier = Modifier.fillMaxSize(),
+        columns = GridCells.Fixed(2),
+        contentPadding = PaddingValues(0.dp)
+    ) {
+        items(list) { description ->
+            LpIconTextCard(
+                icon = Icons.Outlined.Add,
+                description = description
+            ) { card ->
+                // onClick: your functionality here
+                Log.e("tag", card) // show selected card message
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
Added functionality of a Card with icon and text only, also was added a example for usage.
Added Typography to cards
Added example module to easy test the app changes when the app runs

Jira: https://devaptivist.atlassian.net/browse/LP-52?atlOrigin=eyJpIjoiZmExNGU4M2Y1MmY4NDE1OTlkNDY0MTA1NmNjNDM5MjQiLCJwIjoiaiJ9

Code: 
![image](https://user-images.githubusercontent.com/33376944/229615812-a8eb6bf4-2613-48f9-9ca2-e5282878e8ee.png)
![image](https://user-images.githubusercontent.com/33376944/229615856-8e2cfc10-589d-4167-a2cd-afa6bc482aed.png)

Example code usage: 
![image](https://user-images.githubusercontent.com/33376944/229615920-79ac7a81-6e7c-45f2-8c20-4350118f83d7.png)


UI result: 
![image](https://user-images.githubusercontent.com/33376944/229615725-a25ea049-abc9-4adc-997d-999691b2cd4a.png)
