### PR TITLE
Feature/lp70 filled text field password

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/OutlinedTextField.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/OutlinedTextField.kt
@@ -32,12 +32,17 @@ fun LpOutlinedTextFieldPassword(
         value = password,
         onValueChange = {
             showError = false
-            password = it
+            password = it.replace("\n", "").replace("\t", "")
         },
+        colors = TextFieldDefaults.outlinedTextFieldColors(
+            focusedBorderColor = MaterialTheme.colorScheme.onPrimary,
+            focusedLabelColor = MaterialTheme.colorScheme.onPrimary,
+            cursorColor = MaterialTheme.colorScheme.onPrimary
+        ),
         label = { Text(text = stringResource(id = R.string.OTFPasswordLabel)) },
         placeholder = { Text(text = stringResource(id = R.string.OTFPasswordLabel)) },
         visualTransformation = PasswordVisualTransformation(),
-        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Password),
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
         trailingIcon = {
             if (showError) {
                 Icon(
@@ -52,6 +57,8 @@ fun LpOutlinedTextFieldPassword(
                 Text(text = stringResource(id = R.string.OTFPasswordMessageError))
             }
         },
-        isError = showError
+        isError = showError,
+        singleLine = true,
+        maxLines = 1
     )
 }

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/OutlinedTextField.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/OutlinedTextField.kt
@@ -1,0 +1,57 @@
+package com.iteneum.designsystem.components
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import com.iteneum.designsystem.R
+
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LpOutlinedTextFieldPassword(
+) {
+    var password by remember { mutableStateOf("") }
+    var showError by remember { mutableStateOf(false) }
+
+    OutlinedTextField(
+        modifier = Modifier
+            .fillMaxWidth()
+            .onFocusChanged {
+                if (!it.isFocused) {
+                    showError = password.length < 6 && password.isNotEmpty()
+                }
+            },
+        value = password,
+        onValueChange = {
+            showError = false
+            password = it
+        },
+        label = { Text(text = stringResource(id = R.string.OTFPasswordLabel)) },
+        placeholder = { Text(text = stringResource(id = R.string.OTFPasswordLabel)) },
+        visualTransformation = PasswordVisualTransformation(),
+        keyboardOptions = KeyboardOptions.Default.copy(keyboardType = KeyboardType.Password),
+        trailingIcon = {
+            if (showError) {
+                Icon(
+                    imageVector = Icons.Filled.Error,
+                    contentDescription = stringResource(id = R.string.OTFPasswordContentDescriptionError),
+                    tint = MaterialTheme.colorScheme.error
+                )
+            }
+        },
+        supportingText = {
+            if (showError) {
+                Text(text = stringResource(id = R.string.OTFPasswordMessageError))
+            }
+        },
+        isError = showError
+    )
+}

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/OutlinedTextField.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/OutlinedTextField.kt
@@ -8,6 +8,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
@@ -37,7 +38,9 @@ fun LpOutlinedTextFieldPassword(
         colors = TextFieldDefaults.outlinedTextFieldColors(
             focusedBorderColor = MaterialTheme.colorScheme.onPrimary,
             focusedLabelColor = MaterialTheme.colorScheme.onPrimary,
-            cursorColor = MaterialTheme.colorScheme.onPrimary
+            unfocusedBorderColor = MaterialTheme.colorScheme.onPrimary,
+            cursorColor = MaterialTheme.colorScheme.onPrimary,
+            placeholderColor = Color.LightGray
         ),
         label = { Text(text = stringResource(id = R.string.OTFPasswordLabel)) },
         placeholder = { Text(text = stringResource(id = R.string.OTFPasswordLabel)) },

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -1,0 +1,5 @@
+<resources>
+    <string name="OTFPasswordLabel">Password</string>
+    <string name="OTFPasswordContentDescriptionError">Error</string>
+    <string name="OTFPasswordMessageError">At least 6 characters</string>
+</resources>


### PR DESCRIPTION
Added OutlinedTextFieldPassword with example validations (not final validations is just for an example)
Addes String resource for not hardcoded text in composable field

Jira: https://devaptivist.atlassian.net/browse/LP-70?atlOrigin=eyJpIjoiOGIwMTY0ZWU5YThlNDU1MTljZGE4NzhmNzU1ZWU0ZTEiLCJwIjoiaiJ9

Example 1:
![image](https://user-images.githubusercontent.com/33376944/229865679-428080e6-d02a-4e2d-ac10-ae38d70cad89.png)

Example 2:
![image](https://user-images.githubusercontent.com/33376944/229865760-4a6c63ea-4234-40b0-bace-6e6086ff96ca.png)

