### PR TITLE
feature/LP-128 Badge Button corrections/code review

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
@@ -123,6 +123,7 @@ fun LpEditFloatingActionButton(
  *
  * @param modifier to modify box properties that contains: Button & Badge
  * @param badgeNumber to modify the number of notifications shown
+ * @param showBadge to enable the number of notifications to be displayed
  * @param imageVector to modify the icon to be displayed
  * @param onClick high order function, to define button action
  *
@@ -133,7 +134,8 @@ fun LpEditFloatingActionButton(
 @Composable
 fun LpBadgeButton(
     modifier: Modifier = Modifier,
-    badgeNumber: Int,
+    badgeNumber: Int = 0,
+    showBadge: Boolean = false,
     imageVector: ImageVector = Icons.Filled.Notifications,
     onClick: () -> Unit = {}
 ) {
@@ -148,7 +150,7 @@ fun LpBadgeButton(
                 tint = MaterialTheme.colorScheme.onPrimary
             )
         }
-        if (badgeNumber > 0) {
+        if (showBadge) {
             BadgedBox(
                 modifier = Modifier
                     .padding(

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
@@ -12,11 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,8 +20,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.iteneum.designsystem.theme.Drab
-import com.iteneum.designsystem.theme.MintJulep
 import com.iteneum.designsystem.utils.getFileName
 
 /**
@@ -125,45 +119,56 @@ fun LpEditFloatingActionButton(
 }
 
 /**
- * Create [BadgeButton] compose for user's notifications
+ * Function that creates [BadgeButton] compose for user's notifications
  *
  * @param modifier to modify box properties that contains: Button & Badge
  * @param badgeNumber to modify the number of notifications shown
+ * @param imageVector to modify the icon to be displayed
  * @param onClick high order function, to define button action
  *
  * @author Jose Miguel Garcia Reyes
  */
+
 @ExperimentalMaterial3Api
 @Composable
 fun BadgeButton(
     modifier: Modifier = Modifier,
-    onClick: () -> Unit,
-    badgeNumber: Int
+    badgeNumber: Int,
+    imageVector: ImageVector = Icons.Filled.Notifications,
+    onClick: () -> Unit = {}
 ) {
-    Box {
+    Box(modifier = modifier) {
         FilledIconButton(
             onClick = onClick,
-            colors = IconButtonDefaults.filledIconButtonColors(MintJulep)
+            colors = IconButtonDefaults.filledIconButtonColors(MaterialTheme.colorScheme.primary)
         ) {
             Icon(
-                Icons.Filled.Notifications,
-                contentDescription = "Notifications button",
-                tint = Drab
+                imageVector = imageVector,
+                contentDescription = "icon image",
+                tint = MaterialTheme.colorScheme.onPrimary
             )
         }
-
         if (badgeNumber > 0) {
-            BadgedBox(modifier = modifier
-                .padding(horizontal = 15.dp, vertical = 7.dp)
-                .align(Alignment.BottomEnd), badge = {
-                Badge(
-                    modifier = Modifier
-                        .padding(all = 1.dp)
-                        .align(Alignment.TopEnd)
-                ) {
-                    Text(text = badgeNumber.toString())
+            BadgedBox(
+                modifier = Modifier
+                    .padding(
+                        horizontal = 15.dp,
+                        vertical = 7.dp
+                    )
+                    .align(alignment = Alignment.BottomEnd),
+                badge = {
+                    Badge(
+                        modifier = Modifier
+                            .padding(all = 1.dp)
+                            .align(alignment = Alignment.TopEnd)
+                    ) {
+                        Text(
+                            text = badgeNumber.toString(),
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                    }
                 }
-            }) {}
+            ) {}
         }
     }
 }

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
@@ -119,7 +119,7 @@ fun LpEditFloatingActionButton(
 }
 
 /**
- * Function that creates [BadgeButton] compose for user's notifications
+ * Function that creates [LpBadgeButton] compose for user's notifications
  *
  * @param modifier to modify box properties that contains: Button & Badge
  * @param badgeNumber to modify the number of notifications shown
@@ -131,7 +131,7 @@ fun LpEditFloatingActionButton(
 
 @ExperimentalMaterial3Api
 @Composable
-fun BadgeButton(
+fun LpBadgeButton(
     modifier: Modifier = Modifier,
     badgeNumber: Int,
     imageVector: ImageVector = Icons.Filled.Notifications,

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
@@ -18,8 +18,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.iteneum.designsystem.R
 import com.iteneum.designsystem.utils.getFileName
 
 /**
@@ -122,7 +124,7 @@ fun LpEditFloatingActionButton(
  * Function that creates [LpBadgeButton] compose for user's notifications
  *
  * @param modifier to modify box properties that contains: Button & Badge
- * @param badgeNumber to modify the number of notifications shown
+ * @param badgeNumber to modify the string number of notifications shown
  * @param showBadge to enable the number of notifications to be displayed
  * @param imageVector to modify the icon to be displayed
  * @param onClick high order function, to define button action
@@ -134,7 +136,7 @@ fun LpEditFloatingActionButton(
 @Composable
 fun LpBadgeButton(
     modifier: Modifier = Modifier,
-    badgeNumber: Int = 0,
+    badgeNumber: String = "0",
     showBadge: Boolean = false,
     imageVector: ImageVector = Icons.Filled.Notifications,
     onClick: () -> Unit = {}
@@ -146,7 +148,7 @@ fun LpBadgeButton(
         ) {
             Icon(
                 imageVector = imageVector,
-                contentDescription = "icon image",
+                contentDescription = stringResource(R.string.cd_Icon),
                 tint = MaterialTheme.colorScheme.onPrimary
             )
         }
@@ -165,7 +167,7 @@ fun LpBadgeButton(
                             .align(alignment = Alignment.TopEnd)
                     ) {
                         Text(
-                            text = badgeNumber.toString(),
+                            text = badgeNumber,
                             color = MaterialTheme.colorScheme.primary
                         )
                     }

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.iteneum.designsystem.R
+import com.iteneum.designsystem.theme.LeasePertTheme
 import com.iteneum.designsystem.utils.getFileName
 
 /**
@@ -140,6 +141,9 @@ fun LpBadgeButton(
     imageVector: ImageVector = Icons.Filled.Notifications,
     onClick: () -> Unit = {}
 ) {
+    val dp02 = LeasePertTheme.sizes.middleSize
+    val dp16 = LeasePertTheme.sizes.smallSize
+    val dp08 = LeasePertTheme.sizes.smallerSize
     Box(modifier = modifier) {
         FilledIconButton(
             onClick = onClick,
@@ -155,14 +159,14 @@ fun LpBadgeButton(
             BadgedBox(
                 modifier = Modifier
                     .padding(
-                        horizontal = 15.dp,
-                        vertical = 7.dp
+                        horizontal = dp16,
+                        vertical = dp08
                     )
                     .align(alignment = Alignment.BottomEnd),
                 badge = {
                     Badge(
                         modifier = Modifier
-                            .padding(all = 1.dp)
+                            .padding(all = dp02)
                             .align(alignment = Alignment.TopEnd)
                     ) {
                         Text(

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="OTFPasswordLabel">Password</string>
     <string name="OTFPasswordContentDescriptionError">Error</string>
     <string name="OTFPasswordMessageError">At least 6 characters</string>
+    <string name="cd_Icon">icon image</string>
 </resources>


### PR DESCRIPTION
LP-128
https://devaptivist.atlassian.net/browse/LP-128

Within "Button.kt" file, function "BadgeButton" is now able to receive an "image vector" as parameter (icon, in case to changed).

BadgeButton with Icon A & notifications
![foto1](https://user-images.githubusercontent.com/25538206/230687356-73f03b3c-7b86-4166-b22b-c89793fc51c9.png)

BadgeButton with Icon A & no notifications
![foto2](https://user-images.githubusercontent.com/25538206/230687378-5b539428-296a-491c-9728-3d9bc96aff11.png)

BadgeButton with Icon B & notifications
![foto3](https://user-images.githubusercontent.com/25538206/230687392-d6c02a0d-b2f2-4213-a150-116351b14f73.png)

BadgeButton with Icon B & no notifications
![foto4](https://user-images.githubusercontent.com/25538206/230687405-73c5a055-ea10-4a15-9dc7-17c3e6e5eff2.png)
