### PR TITLE
Feature: Adding design system sizes

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/theme/DesignSizes.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/theme/DesignSizes.kt
@@ -1,0 +1,50 @@
+package com.iteneum.designsystem.theme
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class DesignSizes internal constructor(
+
+    val nothingSize: Dp = 0.dp,
+    val midSize: Dp = 0.2.dp,
+    val stroke: Dp = 1.dp,
+    val middleSize: Dp = 2.dp,
+    val minorSmallSize: Dp = 4.dp,
+    val smallerSize: Dp = 8.dp,
+    val midSmallSize: Dp = 12.dp,
+    val smallSize: Dp = 16.dp,
+    val minorRegularSize: Dp = 20.dp,
+    val regularSize: Dp = 24.dp,
+    val mediumSize: Dp = 32.dp,
+    val largeSize: Dp = 40.dp,
+
+    val extraSize1and5: Dp = 1.5.dp,
+    val extraSize6: Dp = 6.dp,
+    val extraSize10: Dp = 10.dp,
+    val extraSize36: Dp = 36.dp,
+    val extraSize44: Dp = 44.dp,
+    val extraSize48: Dp = 48.dp,
+    val extraSize56: Dp = 56.dp,
+    val extraSize64: Dp = 64.dp,
+    val extraSize78: Dp = 78.dp,
+    val extraSize86: Dp = 86.dp,
+    val extraSize88: Dp = 88.dp,
+    val extraSize92: Dp = 92.dp,
+    val extraSize97: Dp = 97.dp,
+    val extraSize104: Dp = 104.dp,
+    val extraSize114: Dp = 114.dp,
+    val extraSize124: Dp = 124.dp,
+    val extraSize128: Dp = 128.dp,
+    val extraSize136: Dp = 136.dp,
+    val extraSize142: Dp = 142.dp,
+    val extraSize175: Dp = 175.dp,
+    val extraSize182: Dp = 182.dp,
+    val extraSize199: Dp = 199.dp,
+    val extraSize280: Dp = 280.dp,
+    val extraSize336: Dp = 336.dp,
+    val extraSize344: Dp = 344.dp,
+    val extraSize360: Dp = 360.dp
+
+)

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/theme/Theme.kt
@@ -5,6 +5,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
 
 private val DarkColorPalette = darkColorScheme(
@@ -76,7 +77,7 @@ fun LeasePertTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     content: @Composable () -> Unit
 ) {
-    val colors = if (darkTheme){
+    val colors = if (darkTheme) {
         DarkColorPalette
     } else {
         LightColorPalette
@@ -87,4 +88,11 @@ fun LeasePertTheme(
         typography = LPTypography,
         content = content
     )
+}
+
+object LeasePertTheme {
+    val sizes: DesignSizes
+        @Composable
+        @ReadOnlyComposable
+        get() = DesignSizes()
 }


### PR DESCRIPTION
Adding design system sizes.

https://devaptivist.atlassian.net/jira/software/projects/LP/boards/4?selectedIssue=LP-131

Example of importing and use:

```
import com.iteneum.designsystem.theme.LeasePertTheme

val dp8 = LeasePertTheme.sizes.smallerSize
```