### PR TITLE
Feature/lp155 refactor filled button

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
@@ -89,7 +89,6 @@ fun LpFilledTonalButton(modifier: Modifier, textButton: String, onClick: () -> U
         Text(text = textButton, style = MaterialTheme.typography.titleSmall)
     }
 }
-
 /**
  * Create [LpEditFloatingActionButton] compose for user's posts
  *

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Button.kt
@@ -79,14 +79,14 @@ fun LpOutlinedButton(
 fun LpFilledTonalButton(modifier: Modifier, textButton: String, onClick: () -> Unit) {
     FilledTonalButton(
         onClick = onClick,
-        modifier = modifier.padding(10.dp),
-        shape = RoundedCornerShape(12.dp),
+        modifier = modifier,
+        shape = RoundedCornerShape(LeasePertTheme.sizes.midSmallSize),
         colors = ButtonDefaults.buttonColors(
             containerColor = MaterialTheme.colorScheme.primary,
             contentColor = MaterialTheme.colorScheme.onPrimary
         )
     ) {
-        Text(text = textButton)
+        Text(text = textButton, style = MaterialTheme.typography.titleSmall)
     }
 }
 


### PR DESCRIPTION
Refactor filled tonal button 
In this component padding was deleted, sizes and typhografies are fixed at leaspert nomenclatures

https://devaptivist.atlassian.net/browse/LP-67?atlOrigin=eyJpIjoiNjZiNjAyNjEyNWRiNDQwZmI5ODM2NjcxNGRhNDZiNjIiLCJwIjoiaiJ9

![Filed tonal button preview](https://user-images.githubusercontent.com/60850861/232828458-2fb23533-2f37-47ab-b3e9-eed90f88321a.jpg)
