### PR TITLE
LP-179-referenceError-CommunityView

### DIFF
--- a/feature/community/build.gradle
+++ b/feature/community/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.android.application'
+    id 'com.android.library'
     id 'org.jetbrains.kotlin.android'
 }
 
@@ -13,6 +13,9 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+        vectorDrawables {
+            useSupportLibrary true
+        }
     }
 
     buildTypes {
@@ -31,10 +34,10 @@ android {
     buildFeatures {
         compose true
     }
-
 }
 
 dependencies {
+
     implementation libs.bundles.compose
 //Modules
     implementation project(":core:designsystem")

--- a/feature/community/src/main/java/com/iteneum/community/presentation/CommunityComposable.kt
+++ b/feature/community/src/main/java/com/iteneum/community/presentation/CommunityComposable.kt
@@ -23,10 +23,10 @@ import com.iteneum.designsystem.theme.LeasePertTheme
  *this view model is used to handle the loading of the components of the interface
  * including icons, text and button click functionality.
  *
- * @author Andrés Ivan Medina Herrera
+ * @author Andres Ivan Medina Herrera
  */
 @Composable
-fun CommunitylistUI() {
+fun CommunityListUI() {
     val cardWidth = LeasePertTheme.sizes.extraSize124
     val cardHeight = LeasePertTheme.sizes.extraSize128
     val cardPadding8 = LeasePertTheme.sizes.smallerSize

--- a/feature/community/src/main/res/values/strings.xml
+++ b/feature/community/src/main/res/values/strings.xml
@@ -5,6 +5,5 @@
     <string name="communityUi_cardButton_communityWall">Community Wall</string>
     <string name="communityUi_cardButton_doItYourself">Do It Yourself</string>
     <string name="communityUi_cardButton_services">Services</string>
-    <string name="communityUi_title_community">Community</string>
     <string name="title_community">Community</string>
 </resources>


### PR DESCRIPTION
   **Task’s name**
reference error - CommunityView

   **Task’s link to navigate to jira**
https://devaptivist.atlassian.net/browse/LP-179?atlOrigin=eyJpIjoiZWRkZjlmNmY0N2IyNDIyYmIyZTE2NmMwZDhiM2RmMGMiLCJwIjoiaiJ9

   **General task’s description of what was added, deleted or updated in the code.**
When trying to call the view of the Community module in the App module, that error is generated

   **Attachment file of how looks your code in the app or in the preview if it is necessary.**


![communityUI](https://user-images.githubusercontent.com/128720218/235193987-978aaa19-d167-4478-8e6e-ae149b532c36.jpg)




# Conflicts:
Renamed reference to ID plugin com.android.library

adding description
+Update on Graddle
+Removed unused string in strings.xml
+reformat communityComposbale.kt
+removed resource to  strings file <string name="uI_title_community">Community</string>
+Used :  <string name="title_community">Community</string>