### PR TITLE
Fix/lp 166 lpphonenumbertext issue

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
@@ -1,6 +1,5 @@
 package com.iteneum.designsystem.components
 
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
@@ -9,10 +8,10 @@ import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.TextFieldValue
@@ -340,7 +339,7 @@ fun DropdownTextField(
  * @param isEnabled Establish the button is enabled and ready to use
  * @param isNotValid Indicates if the value introduced is not valid
  * @param supportTextError Indicates the error message when is not valid
- * @param onPhoneChange Returns value typed, using high order functions
+ * @param onPhoneChanged Returns value typed, using high order functions
  *
  * @author Yaritza Moreno
  * @modifiedBy Jose Miguel Garcia Reyes
@@ -359,7 +358,6 @@ fun LPPhoneNumberText(
     val numbersOnlyExpression = remember { Regex("^\\d*\$") }
     val phoneNumberTransformation = PhoneNumberTransformation()
     val maxCharactersAllowed = 10
-    val context = LocalContext.current
     OutlinedTextField(
         modifier = modifier.fillMaxWidth(),
         label = {
@@ -378,9 +376,7 @@ fun LPPhoneNumberText(
         onValueChange = {
             if (it.matches(numbersOnlyExpression) && it.length <= maxCharactersAllowed)
                 phoneNumberText = it
-            else
-                Toast.makeText(context, "Not a valid input", Toast.LENGTH_SHORT).show()
-            onPhoneChanged(it)
+            onPhoneChanged(phoneNumberText)
         },
         isError = isNotValid,
         supportingText = {
@@ -390,6 +386,7 @@ fun LPPhoneNumberText(
         textStyle = TextStyle(fontSize = 18.sp),
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Number,
+            imeAction = ImeAction.Next
         ),
         visualTransformation = {
             phoneNumberTransformation.filter(AnnotatedString(phoneNumberText))

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
@@ -263,10 +263,10 @@ fun LpOutlinedTextFieldInput(
 }
 
 /**
- * [DropdownTextField] it's a textfield to show a list of items inside a box
+ * [DropdownTextField] it's a text-field to show a list of items inside a box
  *
- * @param title refers to the label that the textfield will have
- * @param items refers to the list that will be given to expand the textfield
+ * @param title refers to the label that the text-field will have
+ * @param items refers to the list that will be given to expand the text-field
  * @param modifier to set component modifier
  * @param selected its a high order function that returns the selected option of the dropdown as result
  *

--- a/feature/repair/src/main/res/values/strings.xml
+++ b/feature/repair/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="label_pet_in_unit">Pet in Unit</string>
     <string name="hint_pet_in_unit">Category</string>
     <string name="text_service">I would like to request a service for…</string>
-    <string name="label_category">Select Category…</string>
+    <string name="label_category">Select category (scroll for options)</string>
     <string name="hint_category">Category</string>
     <string name="label_description">Describe your problem…</string>
     <string name="hint_description">Text</string>

--- a/feature/repair/src/main/res/values/strings.xml
+++ b/feature/repair/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="label_pet_in_unit">Pet in Unit</string>
     <string name="hint_pet_in_unit">Category</string>
     <string name="text_service">I would like to request a service for…</string>
-    <string name="label_category">Category (scroll for more options)</string>
+    <string name="label_category">Select category</string>
     <string name="hint_category">Category</string>
     <string name="label_description">Describe your problem…</string>
     <string name="hint_description">Text</string>

--- a/feature/repair/src/main/res/values/strings.xml
+++ b/feature/repair/src/main/res/values/strings.xml
@@ -11,7 +11,7 @@
     <string name="label_pet_in_unit">Pet in Unit</string>
     <string name="hint_pet_in_unit">Category</string>
     <string name="text_service">I would like to request a service for…</string>
-    <string name="label_category">Select category (scroll for options)</string>
+    <string name="label_category">Category (scroll for more options)</string>
     <string name="hint_category">Category</string>
     <string name="label_description">Describe your problem…</string>
     <string name="hint_description">Text</string>


### PR DESCRIPTION
LP-166 LPPhoneNumberText issue
https://devaptivist.atlassian.net/browse/LP-166
Phone number text field was reading more than 10 digit values. It has been updated.
Added a string for better understanding within Repair View.

Phone Number
![abc](https://user-images.githubusercontent.com/25538206/235212500-b44084c9-1bff-4bf3-b383-8563b755b409.png)
Phone number obtained while testing (Does not have same number, but the max amount of char that reads is 10 digits)
![abc2](https://user-images.githubusercontent.com/25538206/235212588-38cdcbed-230c-4a52-b536-03ce9fb39f50.png)
