### PR TITLE
Fix/LP-187 DropDownTextField length and color

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
@@ -294,7 +294,7 @@ fun DropdownTextField(
                 .fillMaxWidth()
                 .menuAnchor(),
             value = selectedOptionText,
-            onValueChange = { },
+            onValueChange = {/* TODO - DropdownTextField onValueChanged - to implement when value is changed within text field */},
             readOnly = true,
             label = { Text(text = title, color = MaterialTheme.colorScheme.tertiary) },
             trailingIcon = {

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
@@ -3,8 +3,6 @@ package com.iteneum.designsystem.components
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -271,6 +269,7 @@ fun LpOutlinedTextFieldInput(
  * @param selected its a high order function that returns the selected option of the dropdown as result
  *
  * @author Jesus Lopez Gonzalez
+ * @modifiedBy Jose Miguel Garcia Reyes
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -285,7 +284,9 @@ fun DropdownTextField(
 
     ExposedDropdownMenuBox(
         expanded = expanded,
-        onExpandedChange = { expanded = !expanded },
+        onExpandedChange = {
+            expanded = !expanded
+        },
         modifier = modifier
     ) {
         OutlinedTextField(
@@ -293,16 +294,13 @@ fun DropdownTextField(
                 .fillMaxWidth()
                 .menuAnchor(),
             value = selectedOptionText,
-            onValueChange = {},
+            onValueChange = { },
             readOnly = true,
             label = { Text(text = title, color = MaterialTheme.colorScheme.tertiary) },
             trailingIcon = {
-                IconButton(onClick = { expanded = true }) {
-                    Icon(
-                        imageVector = Icons.Default.ArrowDropDown,
-                        contentDescription = stringResource(id = R.string.DTFDropdownDescription)
-                    )
-                }
+                ExposedDropdownMenuDefaults.TrailingIcon(
+                    expanded = expanded
+                )
             },
             colors = TextFieldDefaults.outlinedTextFieldColors(
                 focusedBorderColor = MaterialTheme.colorScheme.onPrimary,
@@ -312,10 +310,14 @@ fun DropdownTextField(
                 placeholderColor = MaterialTheme.colorScheme.onPrimary
             )
         )
-        ExposedDropdownMenu(
-            modifier = Modifier.background(MaterialTheme.colorScheme.primary),
+        DropdownMenu(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.background)
+                .exposedDropdownSize(),
             expanded = expanded,
-            onDismissRequest = { expanded = false }
+            onDismissRequest = {
+                expanded = false
+            }
         ) {
             items.forEach { selectedOption ->
                 DropdownMenuItem(

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/TextField.kt
@@ -263,10 +263,10 @@ fun LpOutlinedTextFieldInput(
 /**
  * [DropdownTextField] it's a text-field to show a list of items inside a box
  *
- * @param title refers to the label that the text-field will have
- * @param items refers to the list that will be given to expand the text-field
  * @param modifier to set component modifier
- * @param selected its a high order function that returns the selected option of the dropdown as result
+ * @param title refers to the label that the text-field will have
+ * @param items refers to the elements of the DropDownList (list of elements)
+ * @param selected refers to a high order function that returns the selected option of the DropDownList
  *
  * @author Jesus Lopez Gonzalez
  * @modifiedBy Jose Miguel Garcia Reyes


### PR DESCRIPTION
LP-187
https://devaptivist.atlassian.net/browse/LP-187
DropDownTextField composable was updated. Background color updated to white. Length was updated. Code refactored. Some improvements on arrow icon. Some elements changed to be able to make the feature. Not warnings or errors showed.

Two TextField using the DropDownTextField in RepairView
![Screenshot 2023-05-02 173249](https://user-images.githubusercontent.com/25538206/235792244-a9a29c8b-5fe5-4bab-bf19-b07a4dd28cb6.png)

DropDownTextField - PetInUnit field
![Screenshot 2023-05-02 173036](https://user-images.githubusercontent.com/25538206/235792271-b2d9dda9-82f4-4407-94e8-dda019b4d00d.png)

DropDownTextField - Category field
![Screenshot 2023-05-02 173052](https://user-images.githubusercontent.com/25538206/235792287-e1c51a81-e2ab-4dd9-8c21-f4924e8660b6.png)
