### PR TITLE
LP189-fix-dashboard-ui

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Card.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Card.kt
@@ -267,12 +267,14 @@ fun LPGenericElevatedCard(
     onButtonClicked: () -> Unit
 ) {
     val colors = MaterialTheme.colorScheme
+    val sizes = LeasePertTheme.sizes
     Card(
         colors = CardDefaults.cardColors(
             containerColor = color,
         ),
         shape = MaterialTheme.shapes.medium.copy(all = CornerSize(LeasePertTheme.sizes.midSmallSize)),
         modifier = modifier
+            .widthIn(sizes.extraSize48, sizes.extraSize336)
     ) {
         Column(
             modifier = Modifier.padding(

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Card.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Card.kt
@@ -274,7 +274,7 @@ fun LPGenericElevatedCard(
         ),
         shape = MaterialTheme.shapes.medium.copy(all = CornerSize(LeasePertTheme.sizes.midSmallSize)),
         modifier = modifier
-            .widthIn(sizes.extraSize48, sizes.extraSize336)
+            .width(sizes.extraSize312)
     ) {
         Column(
             modifier = Modifier.padding(

--- a/core/designsystem/src/main/java/com/iteneum/designsystem/theme/DesignSizes.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/theme/DesignSizes.kt
@@ -49,6 +49,7 @@ data class DesignSizes internal constructor(
     val extraSize182: Dp = 182.dp,
     val extraSize199: Dp = 199.dp,
     val extraSize280: Dp = 280.dp,
+    val extraSize312: Dp = 312.dp,
     val extraSize336: Dp = 336.dp,
     val extraSize344: Dp = 344.dp,
     val extraSize360: Dp = 360.dp

--- a/feature/dashboard/src/main/java/com/iteneum/dashboard/presentation/DashboardView.kt
+++ b/feature/dashboard/src/main/java/com/iteneum/dashboard/presentation/DashboardView.kt
@@ -113,12 +113,14 @@ fun DashboardView(
             // TODO navigate to amenity reservations screen
         }
         Text(
+            modifier = Modifier.padding(bottom = sizes.minorRegularSize),
             text = stringResource(R.string.happening_today),
             style = LPTypography.titleMedium,
             color = MaterialTheme.colorScheme.tertiary
         )
         LazyRow(
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(sizes.smallSize)
         ) {
             items(eventList) { event ->
                 LPGenericElevatedCard(


### PR DESCRIPTION
DashboardView
*Added space between each item list in "happening today section"

LPGenericElevatedCard
* modified min (48dp) and max (336dp) width

Before:
![Imagen de WhatsApp 2023-05-03 a las 11 49 50](https://user-images.githubusercontent.com/33376944/235979071-4f5c0ece-e8f7-4df5-8dd7-b3430924f561.jpg)


Result: 
![image](https://user-images.githubusercontent.com/33376944/236234344-ff2c3562-0121-47ec-905e-3ee46839ff4f.png)