### PR TITLE
Fix size of Button Chip - review 1

### DIFF
--- a/core/designsystem/src/main/java/com/iteneum/designsystem/components/Chips.kt
+++ b/core/designsystem/src/main/java/com/iteneum/designsystem/components/Chips.kt
@@ -45,7 +45,10 @@ fun LpGenericChip(
             .clip(RoundedCornerShape(sizes.smallSize))
             .background(MaterialTheme.colorScheme.primary)
             .padding(
-                all = sizes.midSmallSize,
+                start = sizes.midSmallSize,
+                top = sizes.extraSize6,
+                end = sizes.midSmallSize,
+                bottom = sizes.extraSize6
             )
             .clickable(onClick = onClicked),
         contentAlignment = Alignment.Center


### PR DESCRIPTION
Fixed sizes of padding of button chip
With this task i change the sizes of top and botton paddings, with this change fit well in ApartmentView Module and is the way in how is designed in the figma desing UI (please ignore the bad chip button fit inside the card, because that bad fit is for the long of the date show in the card, that will be other correction).

![Padding of buttons chip fixed](https://user-images.githubusercontent.com/60850861/236491926-0f071501-1490-480e-9559-f1a33158477c.jpg)

https://devaptivist.atlassian.net/browse/LP-178?atlOrigin=eyJpIjoiYjU3NzI0MDUyMDM3NDM4YmEwMWI2NTQ1NDVhNzM5YWEiLCJwIjoiaiJ9